### PR TITLE
Fixed warnings reported by Clang scan-build-4.0

### DIFF
--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -307,7 +307,7 @@ luaH_object_emit_signal(lua_State *L, gint oud,
     g_free(origin);
 
     if(!obj)
-        luaL_error(L, "trying to emit signal on non-object");
+        return luaL_error(L, "trying to emit signal on non-object");
 
     signal_array_t *sigfuncs = signal_lookup(obj->signals, name);
     if (sigfuncs) {

--- a/extension/luajs.c
+++ b/extension/luajs.c
@@ -62,7 +62,7 @@ luaJS_registered_function_callback(JSContextRef context, JSObjectRef fun,
 
     /* At this point, reply was just handled in msg_recv_lua_js_call() below */
 
-    JSValueRef ret;
+    JSValueRef ret = NULL;
 
     if (lua_toboolean(L, -1))
         error = g_strdup(luaL_checkstring(L, -2));

--- a/widgets/image.c
+++ b/widgets/image.c
@@ -52,7 +52,6 @@ luaH_image_scale(lua_State *L)
     g_object_unref(pixbuf);
     gtk_image_set_from_pixbuf(GTK_IMAGE(w->widget), scaled_pixbuf);
     g_object_unref(scaled_pixbuf);
-    pixbuf = scaled_pixbuf;
 
     return 0;
 }


### PR DESCRIPTION
common/luaobject.c:312:46: warning: Access to field 'signals' results in a dereference of a null pointer (loaded from variable 'obj')
    signal_array_t *sigfuncs = signal_lookup(obj->signals, name);
                                             ^~~~~~~~~~~~
1 warning generated.

widgets/image.c:55:5: warning: Value stored to 'pixbuf' is never read
    pixbuf = scaled_pixbuf;
    ^        ~~~~~~~~~~~~~
1 warning generated.

extension/luajs.c:80:5: warning: Undefined or garbage value returned to caller
    return ret;
    ^~~~~~~~~~
1 warning generated.
