### PR TITLE
Fix compilation with older Glib version

### DIFF
--- a/luakit.c
+++ b/luakit.c
@@ -134,6 +134,7 @@ parseopts(int *argc, gchar *argv[], gboolean **nonblock)
         return g_strdupv(argv + 1);
 }
 
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 50
 static GLogWriterOutput
 glib_log_writer(GLogLevelFlags log_level_flags, const GLogField *fields, gsize n_fields, gpointer UNUSED(user_data))
 {
@@ -165,6 +166,7 @@ glib_log_writer(GLogLevelFlags log_level_flags, const GLogField *fields, gsize n
     _log(log_level, code_line, code_file, "%s: %s", log_domain, message);
     return G_LOG_WRITER_HANDLED;
 }
+#endif
 
 gint
 main(gint argc, gchar *argv[])
@@ -205,7 +207,9 @@ main(gint argc, gchar *argv[])
 
     gtk_init(&argc, &argv);
 
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 50
     g_log_set_writer_func(glib_log_writer, NULL, NULL);
+#endif
     init_directories();
     web_context_init();
     ipc_init();


### PR DESCRIPTION
Disable funnel GLib logs through luakit log system if Glib version is
lower than 2.50
